### PR TITLE
Adding option to trust proxy data and IP from X-FORWARDED-FOR header

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ Configuration
 -------
 *   Open /bundles/locate/config/options.php
 *   You can manage the **refresh rate**, **service priority**, **service API information**, and **fallback details**
+*	When operating in the cloud you can enable "trustproxydata" to tell the request to look for the IP from the X-FORWARDED-FOR header
 
 Usage
 -------

--- a/config/options.php
+++ b/config/options.php
@@ -15,9 +15,9 @@ return array(
 	// Service priority
 	// Options: 'MaxMind', 'IPInfoDB', 'FreeGeoIP'
 	'service_priority' => array(
+        'IPInfoDB',
         'FreeGeoIP',
-		'IPInfoDB',
-		//'MaxMind',
+        'MaxMind',
 	),
 
 	// Fallback IP Address

--- a/config/options.php
+++ b/config/options.php
@@ -4,7 +4,7 @@ return array(
 
 	// Number of minutes before location data should be refreshed
 	// Set to "0" to not automatically refresh
-	'refresh_rate' => 1,
+	'refresh_rate' => 0,
 
 	// MaxMind API Key (http://www.maxmind.com/app/web_services#city)
 	'maxmind_key' => '',

--- a/config/options.php
+++ b/config/options.php
@@ -4,7 +4,7 @@ return array(
 
 	// Number of minutes before location data should be refreshed
 	// Set to "0" to not automatically refresh
-	'refresh_rate' => 0,
+	'refresh_rate' => 1,
 
 	// MaxMind API Key (http://www.maxmind.com/app/web_services#city)
 	'maxmind_key' => '',
@@ -15,14 +15,20 @@ return array(
 	// Service priority
 	// Options: 'MaxMind', 'IPInfoDB', 'FreeGeoIP'
 	'service_priority' => array(
+        'FreeGeoIP',
 		'IPInfoDB',
-		'MaxMind',
-		'FreeGeoIP',
+		//'MaxMind',
 	),
 
 	// Fallback IP Address
 	// Allows you to use a fallback IP address when the user's IP
 	// is 127.0.0.1 or cannot be determined
-	'fallback_ip' => '64.90.182.55',
+	'fallback_ip' => '108.168.252.214',
+	
+    // Trust Proxy Data
+    // When running in the cloud behind a load balancer, enable this
+    // option to get the proper end user IP via the "HTTP_X_FORWARDED_FOR"
+    // header rather than the "REMOTE_ADDR" server var
+    'trustproxydata'    => true,
 
 );

--- a/start.php
+++ b/start.php
@@ -1,5 +1,7 @@
 <?php
 
+if(Config::get('locate::options.trustproxydata',false)) Symfony\Component\HttpFoundation\Request::trustProxyData();
+
 Autoloader::map(array(
 	'Locate' => Bundle::path('locate') . '/locate.php',
 ));


### PR DESCRIPTION
When hosting on Amazon or PagodaBox or behind a load balancer Symfony needs to be configured to trust proxy data in order to get the proper end user IP. Added option, updated readme.
