### PR TITLE
Update API endpoints for MaxMind products and services

### DIFF
--- a/services/maxmind.php
+++ b/services/maxmind.php
@@ -15,7 +15,7 @@ class MaxMind
 			'i' => Locate::ip(),
 		);
 
-		$response = @file_get_contents('http://geoip.maxmind.com/b?' . http_build_query($options));
+		$response = @file_get_contents('https://geoip.maxmind.com/b?' . http_build_query($options));
 
 		if ($response !== false)
 		{


### PR DESCRIPTION
MaxMind is beginning to enforce policies around its API endpoints. Endpoints should use the correct hostname for the product or service, and should always use HTTPS.

[Release Note.](https://dev.maxmind.com/geoip/release-notes/2023#api-policies---temporary-enforcement-on-october-17-2023)